### PR TITLE
add description to index page

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Isaac Chung
+description: ML Engineer currently leading applied research efforts in EMEA.
 ---
 
 <center><img src="img/profile-circle.png" width="300" height="300"/></center>


### PR DESCRIPTION
Preview should be fixed as well. Right now it's showing `linkedin &emsp;`